### PR TITLE
feat: add format

### DIFF
--- a/2.0/jpcoar_scm.xsd
+++ b/2.0/jpcoar_scm.xsd
@@ -225,6 +225,7 @@
     <xs:element name="URI" type="jpcoar:URIType"/>
     <xs:element name="mimeType" type="xs:string"/>
     <xs:element name="extent" type="xs:string"/>
+    <xs:element name="format" type="xs:string"/>
     <xs:element name="datasetSeries" type="jpcoar:datasetSeriesType"/>
 
 


### PR DESCRIPTION
ガイドラインの公開、ありがとうございます。

v2を以下のライブラリで使用してみたところ、formatの部分にエラーが発生しました。

https://pypi.org/project/xsd-validator/

正しい修正方法かは自信がありませんが、本リクエストのような形で修正すると、エラーが解消しました。参考になりましたら幸いです。

---

Exception in thread "main" org.xml.sax.SAXParseException; systemId: file:/content/schema/2.0/jpcoar_scm.xsd; lineNumber: 67; columnNumber: 82; src-resolve: Cannot resolve the name 'jpcoar:format' to a(n) 'element declaration' component.
	at org.apache.xerces.util.ErrorHandlerWrapper.createSAXParseException(Unknown Source)
	at org.apache.xerces.util.ErrorHandlerWrapper.error(Unknown Source)
	at org.apache.xerces.impl.XMLErrorReporter.reportError(Unknown Source)
	at org.apache.xerces.impl.xs.traversers.XSDHandler.reportSchemaError(Unknown Source)
	at org.apache.xerces.impl.xs.traversers.XSDHandler.reportSchemaError(Unknown Source)
	at org.apache.xerces.impl.xs.traversers.XSDHandler.getGlobalDecl(Unknown Source)
	at org.apache.xerces.impl.xs.traversers.XSDElementTraverser.traverseLocal(Unknown Source)
	at org.apache.xerces.impl.xs.traversers.XSDHandler.traverseLocalElements(Unknown Source)
	at org.apache.xerces.impl.xs.traversers.XSDHandler.parseSchema(Unknown Source)
	at org.apache.xerces.impl.xs.XMLSchemaLoader.loadSchema(Unknown Source)
	at org.apache.xerces.impl.xs.XMLSchemaLoader.loadGrammar(Unknown Source)
	at org.apache.xerces.impl.xs.XMLSchemaLoader.loadGrammar(Unknown Source)
	at org.apache.xerces.jaxp.validation.BaseSchemaFactory.newSchema(Unknown Source)
	at com.innodata.XsdValidator.main(XsdValidator.java:32)
