### PR TITLE
Link update: JPCOAR web site

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # JPCOAR Schema
 XSD files and documents for JPCOAR schema
 
-- [JPCOAR web site](https://jpcoar.repo.nii.ac.jp/)
+- [JPCOAR web site](https://jpcoar.org/)
 - [JPCOAR Schema Guidlines](https://schema.irdb.nii.ac.jp/)
 - [Update history of JPCOAR Schema](https://schema.irdb.nii.ac.jp/ja/history)


### PR DESCRIPTION
https://jpcoar.org/news/1198/ のニュースにあるように元のリンクが古いので更新